### PR TITLE
More compatible form inputs

### DIFF
--- a/definitions/themes.json
+++ b/definitions/themes.json
@@ -30,6 +30,9 @@
     "background-mod-backdrop": ["opacity(black, 70%)", "opacity(grey-900, 70%)"],
     "background-highlight": ["opacity(grey-100, 10%)", "opacity(grey-900, 10%)"],
 
+    "border-primary": ["grey-400", "grey-400"],
+    "border-subtle": ["opacity(white, 30%)", "opacity(grey-900, 30%)"],
+
     "interaction-normal": ["white", "grey-900"],
     "interaction-hover": ["grey-200", "grey-800"],
     "interaction-active": ["grey-300", "grey-700"],

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@spyrothon/sparx": "workspace:*",
+    "@tanstack/react-table": "^8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.2"

--- a/packages/docs/src/pages/Common.tsx
+++ b/packages/docs/src/pages/Common.tsx
@@ -5,7 +5,6 @@ import {
   Callout,
   Card,
   Clickable,
-  createColumnHelper,
   Header,
   Image,
   Interactive,
@@ -19,6 +18,13 @@ import {
   ThemeProvider,
   useThemeClass,
 } from "@spyrothon/sparx";
+
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
 
 import usePageAccent from "../usePageAccent";
 import PageHeader from "./PageHeader";
@@ -323,6 +329,11 @@ const SAMPLE_TABLE_COLUMNS = [
 ];
 
 function TableComponent() {
+  const table = useReactTable({
+    data: SAMPLE_TABLE_DATA,
+    columns: SAMPLE_TABLE_COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+  });
   return (
     <Stack as={Section} spacing="space-lg">
       <Header tag="h2">Table</Header>
@@ -335,7 +346,32 @@ function TableComponent() {
         props from the <code>useReactTable</code> function defined there.
       </Text>
       <Stack as={Card} direction="horizontal">
-        <Table columns={SAMPLE_TABLE_COLUMNS} data={SAMPLE_TABLE_DATA} />
+        <Table>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <Table.HeaderRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <Table.Heading key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </Table.Heading>
+                ))}
+              </Table.HeaderRow>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <Table.Row key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <Table.Cell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </Table.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </tbody>
+        </Table>
       </Stack>
     </Stack>
   );

--- a/packages/docs/src/pages/Common.tsx
+++ b/packages/docs/src/pages/Common.tsx
@@ -5,12 +5,14 @@ import {
   Callout,
   Card,
   Clickable,
+  createColumnHelper,
   Header,
   Image,
   Interactive,
   ProgressBar,
   Section,
   Stack,
+  Table,
   Tag,
   Text,
   Theme,
@@ -294,6 +296,51 @@ function TagComponent() {
   );
 }
 
+interface TableEntry {
+  name: string;
+  species: string;
+  color: string;
+}
+
+const SAMPLE_TABLE_DATA = [
+  { name: "Spyro", species: "Dragon", color: "Purple" },
+  { name: "Sparx", species: "Dragonfly", color: "Gold" },
+  { name: "Elora", species: "Fawn", color: "Tan" },
+];
+
+const tableColumnHelper = createColumnHelper<TableEntry>();
+
+const SAMPLE_TABLE_COLUMNS = [
+  tableColumnHelper.accessor("name", {
+    cell: (info) => info.getValue(),
+  }),
+  tableColumnHelper.accessor("species", {
+    cell: (info) => info.getValue(),
+  }),
+  tableColumnHelper.accessor("color", {
+    cell: (info) => info.getValue(),
+  }),
+];
+
+function TableComponent() {
+  return (
+    <Stack as={Section} spacing="space-lg">
+      <Header tag="h2">Table</Header>
+      <Text>
+        <code>Table</code> provides a comfortable layout for tabular data, able to display any kind
+        of content in any number of structures.
+      </Text>
+      <Text>
+        <code>Table</code> is powered by <code>@tanstack/react-table</code> and inherits all of its
+        props from the <code>useReactTable</code> function defined there.
+      </Text>
+      <Stack as={Card} direction="horizontal">
+        <Table columns={SAMPLE_TABLE_COLUMNS} data={SAMPLE_TABLE_DATA} />
+      </Stack>
+    </Stack>
+  );
+}
+
 export default function Common() {
   usePageAccent(Accent.PURPLE);
 
@@ -310,6 +357,7 @@ export default function Common() {
       <AppContainerComponent />
       <ProgressBarComponent />
       <TagComponent />
+      <TableComponent />
     </Stack>
   );
 }

--- a/packages/docs/src/pages/Forms.tsx
+++ b/packages/docs/src/pages/Forms.tsx
@@ -157,7 +157,7 @@ function TextInputComponent() {
           color="blank"
           label="Blank Input Example"
           note="Providing a label and note make it more clear that the input is editable.">
-          <CurrencyInput color="inherit" value={currency} onChange={setCurrency} />
+          <CurrencyInput color="inherit" value={currency} onValueChange={setCurrency} />
         </FormControl>
         <FormControl color="success" label="Or a Prefix" prefix="twitch.tv/">
           <TextInput color="blank" />
@@ -194,7 +194,7 @@ function TextInputVariations() {
         number of seconds.
       </Text>
       <Stack as={Card} spacing="space-md">
-        <DurationInput value={duration} onChange={setDuration} />
+        <DurationInput value={duration} onValueChange={setDuration} />
         <Text>Duration value is {duration} seconds</Text>
       </Stack>
       <Header tag="h3" variant="header-md/normal">
@@ -213,7 +213,7 @@ function TextInputVariations() {
         <code>0</code>, <code>0</code>.
       </Text>
       <Stack as={Card} spacing="space-md">
-        <CurrencyInput value={currency} onChange={setCurrency} />
+        <CurrencyInput value={currency} onValueChange={setCurrency} />
         <Text>Currency value is {currency}</Text>
       </Stack>
     </Stack>

--- a/packages/sparx/package.json
+++ b/packages/sparx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spyrothon/sparx",
   "description": "A React-based design system for Spyrothon",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/sparx/public/.design_system/generated/Themes.css
+++ b/packages/sparx/public/.design_system/generated/Themes.css
@@ -49,6 +49,8 @@
   --background-mod-subtle: rgba(27, 31, 36, 10%);
   --background-mod-backdrop: rgba(27, 31, 36, 70%);
   --background-highlight: rgba(241, 236, 237, 10%);
+  --border-primary: var(--grey-400);
+  --border-subtle: rgba(255, 255, 255, 10%);
   --interactive-normal: var(--white);
   --interactive-hover: var(--grey-200);
   --interactive-active: var(--grey-300);
@@ -105,6 +107,8 @@
   --background-mod-subtle: rgba(26, 23, 24, 10%);
   --background-mod-backdrop: rgba(26, 23, 24, 70%);
   --background-highlight: rgba(26, 23, 24, 10%);
+  --border-primary: var(--grey-400);
+  --border-subtle: rgba(26, 23, 24, 10%);
   --interactive-normal: var(--grey-900);
   --interactive-hover: var(--grey-600);
   --interactive-active: var(--grey-500);

--- a/packages/sparx/public/.design_system/themes.json
+++ b/packages/sparx/public/.design_system/themes.json
@@ -30,6 +30,9 @@
     "background-mod-backdrop": ["opacity(black, 70%)", "opacity(grey-900, 70%)"],
     "background-highlight": ["opacity(grey-100, 10%)", "opacity(grey-900, 10%)"],
 
+    "border-primary": ["grey-400", "grey-400"],
+    "border-subtle": ["opacity(white, 10%)", "opacity(grey-900, 10%)"],
+
     "interactive-normal": ["white", "grey-900"],
     "interactive-hover": ["grey-200", "grey-600"],
     "interactive-active": ["grey-300", "grey-500"],

--- a/packages/sparx/src/components/forms/Checkbox.tsx
+++ b/packages/sparx/src/components/forms/Checkbox.tsx
@@ -18,7 +18,10 @@ export interface CheckboxProps {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => unknown;
 }
 
-export function Checkbox(props: CheckboxProps) {
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  props,
+  ref,
+) {
   const { checked, label, color = "accent", disabled = false, onChange } = props;
   const [inputId] = React.useState(() => uuid.v4());
 
@@ -41,6 +44,7 @@ export function Checkbox(props: CheckboxProps) {
       })}
       htmlFor={inputId}>
       <input
+        ref={ref}
         type="checkbox"
         style={{ display: "none" }}
         id={inputId}
@@ -52,4 +56,4 @@ export function Checkbox(props: CheckboxProps) {
       {labelNode}
     </Clickable>
   );
-}
+});

--- a/packages/sparx/src/components/forms/FormSwitch.tsx
+++ b/packages/sparx/src/components/forms/FormSwitch.tsx
@@ -30,7 +30,10 @@ function renderSwitch() {
   );
 }
 
-export function FormSwitch(props: FormSwitchProps) {
+export const FormSwitch = React.forwardRef<HTMLInputElement, FormSwitchProps>(function FormSwitch(
+  props,
+  ref,
+) {
   const { checked, disabled = false, color = "accent", label, note, onChange } = props;
   const [inputId] = React.useState(() => uuid.v4());
 
@@ -52,6 +55,7 @@ export function FormSwitch(props: FormSwitchProps) {
         </Text>
         {renderSwitch()}
         <input
+          ref={ref}
           type="checkbox"
           disabled={disabled}
           onChange={onChange}
@@ -65,4 +69,4 @@ export function FormSwitch(props: FormSwitchProps) {
       </Text>
     </div>
   );
-}
+});

--- a/packages/sparx/src/components/forms/formatted_inputs/CurrencyInput.tsx
+++ b/packages/sparx/src/components/forms/formatted_inputs/CurrencyInput.tsx
@@ -8,38 +8,48 @@ export interface CurrencyInputProps extends Omit<TextInputProps, "type" | "value
    * An integer value representing hundredths (cents) for the currency amount.
    */
   value: number;
-  onChange: (value: number, event: React.SyntheticEvent<HTMLInputElement>) => unknown;
+  onChange: (event: React.SyntheticEvent<HTMLInputElement>, value: number) => unknown;
   locale?: string;
   currency?: string;
 }
 
-export function CurrencyInput(props: CurrencyInputProps) {
-  const { value = 0, onChange, locale = "en-US", currency = "USD", ...otherProps } = props;
-  const [formatter] = React.useMemo(
-    () => [
-      new NumberFormatter(locale, {
-        style: "currency",
-        currency,
-        minimumIntegerDigits: 1,
-        maximumFractionDigits: 2,
-      }),
-    ],
-    [locale, currency],
-  );
+export const CurrencyInput = React.forwardRef<HTMLInputElement, CurrencyInputProps>(
+  function CurrencyInput(props, ref) {
+    const { value = 0, onChange, locale = "en-US", currency = "USD", ...otherProps } = props;
+    const [formatter] = React.useMemo(
+      () => [
+        new NumberFormatter(locale, {
+          style: "currency",
+          currency,
+          minimumIntegerDigits: 1,
+          maximumFractionDigits: 2,
+        }),
+      ],
+      [locale, currency],
+    );
 
-  const [formattedValue, setFormattedValue] = React.useState(() => formatter.format(value / 100));
+    const [formattedValue, setFormattedValue] = React.useState(() => formatter.format(value / 100));
 
-  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
-    let newValue = value;
-    if (event.key === "Backspace") {
-      newValue = Math.floor(value / 10);
-    } else if (!Number.isNaN(Number(event.key))) {
-      newValue = value * 10 + Number(event.key);
+    function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+      let newValue = value;
+      if (event.key === "Backspace") {
+        newValue = Math.floor(value / 10);
+      } else if (!Number.isNaN(Number(event.key))) {
+        newValue = value * 10 + Number(event.key);
+      }
+
+      setFormattedValue(formatter.format(newValue / 100));
+      onChange(event, newValue);
     }
 
-    setFormattedValue(formatter.format(newValue / 100));
-    onChange(newValue, event);
-  }
-
-  return <TextInput {...otherProps} type="text" value={formattedValue} onKeyDown={handleKeyDown} />;
-}
+    return (
+      <TextInput
+        ref={ref}
+        {...otherProps}
+        type="text"
+        value={formattedValue}
+        onKeyDown={handleKeyDown}
+      />
+    );
+  },
+);

--- a/packages/sparx/src/components/forms/formatted_inputs/CurrencyInput.tsx
+++ b/packages/sparx/src/components/forms/formatted_inputs/CurrencyInput.tsx
@@ -8,14 +8,22 @@ export interface CurrencyInputProps extends Omit<TextInputProps, "type" | "value
    * An integer value representing hundredths (cents) for the currency amount.
    */
   value: number;
-  onChange: (event: React.SyntheticEvent<HTMLInputElement>, value: number) => unknown;
+  onChange?: (event: React.SyntheticEvent<HTMLInputElement>, value: number) => unknown;
+  onValueChange?: (value: number) => unknown;
   locale?: string;
   currency?: string;
 }
 
 export const CurrencyInput = React.forwardRef<HTMLInputElement, CurrencyInputProps>(
   function CurrencyInput(props, ref) {
-    const { value = 0, onChange, locale = "en-US", currency = "USD", ...otherProps } = props;
+    const {
+      value = 0,
+      onChange,
+      onValueChange,
+      locale = "en-US",
+      currency = "USD",
+      ...otherProps
+    } = props;
     const [formatter] = React.useMemo(
       () => [
         new NumberFormatter(locale, {
@@ -39,7 +47,8 @@ export const CurrencyInput = React.forwardRef<HTMLInputElement, CurrencyInputPro
       }
 
       setFormattedValue(formatter.format(newValue / 100));
-      onChange(event, newValue);
+      onChange?.(event, newValue);
+      onValueChange?.(newValue);
     }
 
     return (

--- a/packages/sparx/src/components/forms/formatted_inputs/DateTimeInput.tsx
+++ b/packages/sparx/src/components/forms/formatted_inputs/DateTimeInput.tsx
@@ -5,23 +5,26 @@ import { formatDateTimeLocalToString } from "@sparx/utils/DateTimeUtils";
 
 export interface DateTimeInputProps extends Omit<TextInputProps, "type" | "value" | "onChange"> {
   value?: Date;
-  onChange: (value: Date) => unknown;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>, value: Date) => unknown;
 }
 
-export function DateTimeInput(props: DateTimeInputProps) {
-  const { value, onChange, ...otherProps } = props;
+export const DateTimeInput = React.forwardRef<HTMLInputElement, DateTimeInputProps>(
+  function DateTimeInput(props, ref) {
+    const { value, onChange, ...otherProps } = props;
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const value = new Date(event.target.value);
-    onChange(value);
-  }
+    function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+      const value = new Date(event.target.value);
+      onChange(event, value);
+    }
 
-  return (
-    <TextInput
-      {...otherProps}
-      type="datetime-local"
-      value={formatDateTimeLocalToString(value)}
-      onChange={handleChange}
-    />
-  );
-}
+    return (
+      <TextInput
+        ref={ref}
+        {...otherProps}
+        type="datetime-local"
+        value={formatDateTimeLocalToString(value)}
+        onChange={handleChange}
+      />
+    );
+  },
+);

--- a/packages/sparx/src/components/forms/formatted_inputs/DateTimeInput.tsx
+++ b/packages/sparx/src/components/forms/formatted_inputs/DateTimeInput.tsx
@@ -5,16 +5,18 @@ import { formatDateTimeLocalToString } from "@sparx/utils/DateTimeUtils";
 
 export interface DateTimeInputProps extends Omit<TextInputProps, "type" | "value" | "onChange"> {
   value?: Date;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>, value: Date) => unknown;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>, value: Date) => unknown;
+  onValueChange?: (value: Date) => unknown;
 }
 
 export const DateTimeInput = React.forwardRef<HTMLInputElement, DateTimeInputProps>(
   function DateTimeInput(props, ref) {
-    const { value, onChange, ...otherProps } = props;
+    const { value, onChange, onValueChange, ...otherProps } = props;
 
     function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
       const value = new Date(event.target.value);
-      onChange(event, value);
+      onChange?.(event, value);
+      onValueChange?.(value);
     }
 
     return (

--- a/packages/sparx/src/components/forms/formatted_inputs/DurationInput.tsx
+++ b/packages/sparx/src/components/forms/formatted_inputs/DurationInput.tsx
@@ -5,12 +5,13 @@ import DurationUtils from "@sparx/utils/DurationUtils";
 
 export interface DurationInputProps extends Omit<TextInputProps, "type" | "value" | "onChange"> {
   value?: number;
-  onChange: (event: React.SyntheticEvent<HTMLInputElement>, value: number) => unknown;
+  onChange?: (event: React.SyntheticEvent<HTMLInputElement>, value: number) => unknown;
+  onValueChange?: (value: number) => unknown;
 }
 
 export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputProps>(
   function DurationInput(props, ref) {
-    const { value, onChange, placeholder = "hh:mm:ss", ...otherProps } = props;
+    const { value, onChange, onValueChange, placeholder = "hh:mm:ss", ...otherProps } = props;
     const [renderedValue, setRenderedValue] = React.useState(() => DurationUtils.toString(value));
 
     React.useEffect(() => {
@@ -22,7 +23,8 @@ export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputPro
     // value on every change will cause unusable formatting.
     function handleBlur(event: React.FocusEvent<HTMLInputElement>) {
       const duration = DurationUtils.fromString(event.target.value);
-      onChange(event, duration);
+      onChange?.(event, duration);
+      onValueChange?.(duration);
     }
 
     return (

--- a/packages/sparx/src/components/forms/formatted_inputs/DurationInput.tsx
+++ b/packages/sparx/src/components/forms/formatted_inputs/DurationInput.tsx
@@ -5,33 +5,36 @@ import DurationUtils from "@sparx/utils/DurationUtils";
 
 export interface DurationInputProps extends Omit<TextInputProps, "type" | "value" | "onChange"> {
   value?: number;
-  onChange: (value: number) => unknown;
+  onChange: (event: React.SyntheticEvent<HTMLInputElement>, value: number) => unknown;
 }
 
-export function DurationInput(props: DurationInputProps) {
-  const { value, onChange, placeholder = "hh:mm:ss", ...otherProps } = props;
-  const [renderedValue, setRenderedValue] = React.useState(() => DurationUtils.toString(value));
+export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputProps>(
+  function DurationInput(props, ref) {
+    const { value, onChange, placeholder = "hh:mm:ss", ...otherProps } = props;
+    const [renderedValue, setRenderedValue] = React.useState(() => DurationUtils.toString(value));
 
-  React.useEffect(() => {
-    setRenderedValue(DurationUtils.toString(value));
-  }, [value]);
+    React.useEffect(() => {
+      setRenderedValue(DurationUtils.toString(value));
+    }, [value]);
 
-  // This only updates on blur because the string representation of the time
-  // doesn't line up with the numeric representation, meaning updating the
-  // value on every change will cause unusable formatting.
-  function handleBlur(event: React.FocusEvent<HTMLInputElement>) {
-    const duration = DurationUtils.fromString(event.target.value);
-    onChange(duration);
-  }
+    // This only updates on blur because the string representation of the time
+    // doesn't line up with the numeric representation, meaning updating the
+    // value on every change will cause unusable formatting.
+    function handleBlur(event: React.FocusEvent<HTMLInputElement>) {
+      const duration = DurationUtils.fromString(event.target.value);
+      onChange(event, duration);
+    }
 
-  return (
-    <TextInput
-      {...otherProps}
-      type="text"
-      value={renderedValue}
-      placeholder={placeholder}
-      onBlur={handleBlur}
-      onChange={(event) => setRenderedValue(event.target.value)}
-    />
-  );
-}
+    return (
+      <TextInput
+        ref={ref}
+        {...otherProps}
+        type="text"
+        value={renderedValue}
+        placeholder={placeholder}
+        onBlur={handleBlur}
+        onChange={(event) => setRenderedValue(event.target.value)}
+      />
+    );
+  },
+);

--- a/packages/sparx/src/components/table/Table.module.css
+++ b/packages/sparx/src/components/table/Table.module.css
@@ -1,0 +1,11 @@
+.table {
+  width: 100%;
+  border-radius: var(--radius-normal);
+  background-color: var(--background-floating);
+  color: var(--text-normal);
+
+  & th,
+  & td {
+    padding: var(--space-sm) var(--space-md);
+  }
+}

--- a/packages/sparx/src/components/table/Table.module.css
+++ b/packages/sparx/src/components/table/Table.module.css
@@ -1,11 +1,23 @@
 .table {
   width: 100%;
   border-radius: var(--radius-normal);
-  background-color: var(--background-floating);
   color: var(--text-normal);
+  border-collapse: collapse;
+}
 
-  & th,
-  & td {
+.headerRow .heading {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.cozy {
+  & .heading,
+  & .cell {
+    padding: var(--space-md) var(--space-lg);
+  }
+}
+.compact {
+  & .heading,
+  & .cell {
     padding: var(--space-sm) var(--space-md);
   }
 }

--- a/packages/sparx/src/components/table/Table.tsx
+++ b/packages/sparx/src/components/table/Table.tsx
@@ -1,50 +1,57 @@
 import * as React from "react";
-
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  TableOptions,
-  useReactTable,
-} from "@tanstack/react-table";
-export { createColumnHelper };
+import classNames from "classnames";
 
 import styles from "./Table.module.css";
 
-export interface TableProps<T> extends Omit<TableOptions<T>, "getCoreRowModel"> {
-  getCoreRowModel?: TableOptions<T>["getCoreRowModel"];
+export type TableSpacing = "cozy" | "compact";
+
+export interface TableProps extends React.PropsWithChildren {
+  spacing?: TableSpacing;
+  className?: string;
 }
 
-export function Table<T>(props: TableProps<T>) {
-  const table = useReactTable({
-    ...props,
-    getCoreRowModel: props.getCoreRowModel ?? getCoreRowModel(),
-  });
-
-  return (
-    <table className={styles.table}>
-      <thead>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <tr key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <th key={header.id}>
-                {header.isPlaceholder
-                  ? null
-                  : flexRender(header.column.columnDef.header, header.getContext())}
-              </th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody>
-        {table.getRowModel().rows.map((row) => (
-          <tr key={row.id}>
-            {row.getVisibleCells().map((cell) => (
-              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
+export function Table(props: TableProps) {
+  const { spacing = "cozy", className, children } = props;
+  return <table className={classNames(styles.table, styles[spacing], className)}>{children}</table>;
 }
+
+export interface TableHeaderRowProps extends React.PropsWithChildren {
+  className?: string;
+}
+
+function TableHeaderRow(props: TableHeaderRowProps) {
+  const { className, children } = props;
+  return <tr className={classNames(styles.headerRow, className)}>{children}</tr>;
+}
+
+export interface TableHeadingProps extends React.PropsWithChildren {
+  className?: string;
+}
+
+function TableHeading(props: TableHeadingProps) {
+  const { className, children } = props;
+  return <th className={classNames(styles.heading, className)}>{children}</th>;
+}
+
+export interface TableRowProps extends React.PropsWithChildren {
+  className?: string;
+}
+
+function TableRow(props: TableRowProps) {
+  const { className, children } = props;
+  return <tr className={classNames(styles.row, className)}>{children}</tr>;
+}
+
+export interface TableCellProps extends React.PropsWithChildren {
+  className?: string;
+}
+
+function TableCell(props: TableCellProps) {
+  const { className, children } = props;
+  return <td className={classNames(styles.cell, className)}>{children}</td>;
+}
+
+Table.Heading = TableHeading;
+Table.HeaderRow = TableHeaderRow;
+Table.Cell = TableCell;
+Table.Row = TableRow;

--- a/packages/sparx/src/components/table/Table.tsx
+++ b/packages/sparx/src/components/table/Table.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  TableOptions,
+  useReactTable,
+} from "@tanstack/react-table";
+export { createColumnHelper };
+
+import styles from "./Table.module.css";
+
+export interface TableProps<T> extends Omit<TableOptions<T>, "getCoreRowModel"> {
+  getCoreRowModel?: TableOptions<T>["getCoreRowModel"];
+}
+
+export function Table<T>(props: TableProps<T>) {
+  const table = useReactTable({
+    ...props,
+    getCoreRowModel: props.getCoreRowModel ?? getCoreRowModel(),
+  });
+
+  return (
+    <table className={styles.table}>
+      <thead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <th key={header.id}>
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(header.column.columnDef.header, header.getContext())}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/packages/sparx/src/index.tsx
+++ b/packages/sparx/src/index.tsx
@@ -94,6 +94,9 @@ export type {
   Spacing,
 } from "./components/layout/Stack";
 
+export { Table, createColumnHelper } from "./components/table/Table";
+export type { TableProps } from "./components/table/Table";
+
 export { Markdown } from "./components/text/Markdown";
 export type { MarkdownProps } from "./components/text/Markdown";
 export { Header, Text } from "./components/text/Text";

--- a/packages/sparx/src/index.tsx
+++ b/packages/sparx/src/index.tsx
@@ -94,7 +94,7 @@ export type {
   Spacing,
 } from "./components/layout/Stack";
 
-export { Table, createColumnHelper } from "./components/table/Table";
+export { Table } from "./components/table/Table";
 export type { TableProps } from "./components/table/Table";
 
 export { Markdown } from "./components/text/Markdown";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ importers:
   packages/docs:
     specifiers:
       '@spyrothon/sparx': workspace:*
+      '@tanstack/react-table': ^8.9.3
       '@types/node': ^18.8.5
       '@types/react': ^18.0.17
       '@types/react-dom': ^18.0.6
@@ -41,6 +42,7 @@ importers:
       vite: ^3.1.0
     dependencies:
       '@spyrothon/sparx': link:../sparx
+      '@tanstack/react-table': 8.9.3_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router-dom: 6.4.2_biqbaboplfbrettd7655fr4n2y
@@ -845,6 +847,18 @@ packages:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.4.0
+    dev: false
+
+  /@tanstack/react-table/8.9.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-Ng9rdm3JPoSCi6cVZvANsYnF+UoGVRxflMb270tVj0+LjeT/ZtZ9ckxF6oLPLcKesza6VKBqtdF9mQ+vaz24Aw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@tanstack/table-core': 8.9.3
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: false
 
   /@tanstack/react-table/8.9.3_yicqvriqha7ppr6zyvk5y4bjya:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,7 @@ importers:
       '@iconscout/react-unicons': ^1.1.6
       '@iconscout/react-unicons-solid': ^0.0.3
       '@internationalized/number': ^3.2.0
+      '@tanstack/react-table': ^8.9.3
       '@types/node': ^18.8.5
       '@types/react': ^18.0.17
       '@types/react-dom': ^18.0.6
@@ -77,10 +78,11 @@ importers:
       '@iconscout/react-unicons': 1.1.6_react@16.14.0
       '@iconscout/react-unicons-solid': 0.0.3_react@16.14.0
       '@internationalized/number': 3.2.0
+      '@tanstack/react-table': 8.9.3_yicqvriqha7ppr6zyvk5y4bjya
       classnames: 2.3.2
       downshift: 6.1.12_react@16.14.0
       react: 16.14.0
-      react-dom: 18.2.0_react@18.2.0
+      react-dom: 18.2.0_react@16.14.0
       react-polymorphic-types: github.com/GamesDoneQuick/react-polymorphic-types/bd1e8388c1d02d919dd038a5d5690ff7bb62da88_@types+react@18.0.21
       react-remark: 2.1.0_react@16.14.0
       uuid: 8.3.2
@@ -843,6 +845,23 @@ packages:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.4.0
+    dev: false
+
+  /@tanstack/react-table/8.9.3_yicqvriqha7ppr6zyvk5y4bjya:
+    resolution: {integrity: sha512-Ng9rdm3JPoSCi6cVZvANsYnF+UoGVRxflMb270tVj0+LjeT/ZtZ9ckxF6oLPLcKesza6VKBqtdF9mQ+vaz24Aw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@tanstack/table-core': 8.9.3
+      react: 16.14.0
+      react-dom: 18.2.0_react@16.14.0
+    dev: false
+
+  /@tanstack/table-core/8.9.3:
+    resolution: {integrity: sha512-NpHZBoHTfqyJk0m/s/+CSuAiwtebhYK90mDuf5eylTvgViNOujiaOaxNDxJkQQAsVvHWZftUGAx1EfO1rkKtLg==}
+    engines: {node: '>=12'}
     dev: false
 
   /@types/history/4.7.11:
@@ -2591,6 +2610,16 @@ packages:
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
+
+  /react-dom/18.2.0_react@16.14.0:
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: 1.4.0
+      react: 16.14.0
+      scheduler: 0.23.0
+    dev: false
 
   /react-dom/18.2.0_react@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}


### PR DESCRIPTION
This makes all form inputs (other than RadioGroup and Select) forward their refs to the internal `input` element, and also makes all of the formatted input callbacks consistent with their native input, while also providing an `onValueChange` to still get the formatted value out easily.

All of this should mean that this library becomes much more compatible with things like `react-hook-form`.